### PR TITLE
feat: Add MongoDB document conversion methods to ServiceAccount model

### DIFF
--- a/src/models/service_account.rs
+++ b/src/models/service_account.rs
@@ -48,6 +48,16 @@ impl ServiceAccount {
     pub fn enabled(&self) -> bool {
         self.enabled
     }
+
+    // Convert to MongoDB Document
+    pub fn to_document(&self) -> Result<mongodb::bson::Document, mongodb::bson::ser::Error> {
+        mongodb::bson::to_document(self)
+    }
+
+    // Create from MongoDB Document
+    pub fn from_document(doc: mongodb::bson::Document) -> Result<Self, mongodb::bson::de::Error> {
+        mongodb::bson::from_document(doc)
+    }    
 }
 
 #[cfg(test)]
@@ -68,6 +78,7 @@ mod test {
         assert_eq!(service_account.user, user);
         assert_eq!(service_account.secret, secret);
     }
+   
     #[test]
     fn test_serialization() {
         let email = "Examples@google.com".to_string();
@@ -88,5 +99,25 @@ mod test {
             service_account.enabled,
             deserialized_service_account.enabled
         );
+    }
+
+    #[test]
+    fn test_mongodb_serialization() {
+        let email = "Examples@google.com".to_string();
+        let user = "Example123".to_string();
+        let secret = "ExampleSercet".to_string();
+        let service_account = ServiceAccount::new(email.clone(), user.clone(), secret.clone());
+
+        // Test conversion to BSON Document
+        let doc = service_account.to_document().unwrap();
+        
+        // Test conversion from BSON Document
+        let deserialized = ServiceAccount::from_document(doc).unwrap();
+
+        assert_eq!(service_account.id, deserialized.id);
+        assert_eq!(service_account.email, deserialized.email);
+        assert_eq!(service_account.user, deserialized.user);
+        assert_eq!(service_account.secret, deserialized.secret);
+        assert_eq!(service_account.enabled, deserialized.enabled);
     }
 }


### PR DESCRIPTION
This PR adds MongoDB document conversion methods to the ServiceAccount model, enabling seamless integration with MongoDB.

Changes:
- Added `to_document` method to convert ServiceAccount struct to MongoDB document
- Added `from_document` method to create ServiceAccount struct from MongoDB document
- Added comprehensive unit tests for MongoDB serialization/deserialization

Technical Details:
- Implemented BSON serialization/deserialization using MongoDB's bson crate
- Added proper error handling for document conversion operations
- Ensured type safety with proper return types (Result<mongodb::bson::Document, mongodb::bson::ser::Error>)

Testing:
- Added unit tests for MongoDB document conversion
- Verified proper serialization/deserialization of all ServiceAccount fields:
  - id
  - email
  - user
  - secret
  - enabled
- Ensured backward compatibility with existing code

Related Issues:
- Closes #20