### PR TITLE
Add test coverage for Algorithm serialization/deserialization

### DIFF
--- a/src/serializers/algorithm.rs
+++ b/src/serializers/algorithm.rs
@@ -23,3 +23,55 @@ where
         _ => Err(serde::de::Error::custom("Invalid algorithm type")),
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde::{Serialize, Deserialize};
+    use serde_json;
+
+    #[derive(Serialize, Deserialize)]
+    struct TestStruct {
+        #[serde(serialize_with = "serialize", deserialize_with = "deserialize")]
+        algorithm: Algorithm,
+    }
+
+    #[test]
+    fn test_serialize_rsa() {
+        let test_struct = TestStruct {
+            algorithm: Algorithm::RSA,
+        };
+        let serialized = serde_json::to_string(&test_struct).unwrap();
+        assert_eq!(serialized, r#"{"algorithm":"RSA"}"#);
+    }
+
+    #[test]
+    fn test_serialize_hmac() {
+        let test_struct = TestStruct {
+            algorithm: Algorithm::HMAC,
+        };
+        let serialized = serde_json::to_string(&test_struct).unwrap();
+        assert_eq!(serialized, r#"{"algorithm":"HMAC"}"#);
+    }
+
+    #[test]
+    fn test_deserialize_rsa() {
+        let json = r#"{"algorithm":"RSA"}"#;
+        let deserialized: TestStruct = serde_json::from_str(json).unwrap();
+        assert!(matches!(deserialized.algorithm, Algorithm::RSA));
+    }
+
+    #[test]
+    fn test_deserialize_hmac() {
+        let json = r#"{"algorithm":"HMAC"}"#;
+        let deserialized: TestStruct = serde_json::from_str(json).unwrap();
+        assert!(matches!(deserialized.algorithm, Algorithm::HMAC));
+    }
+
+    #[test]
+    fn test_deserialize_invalid() {
+        let json = r#"{"algorithm":"INVALID"}"#;
+        let result: Result<TestStruct, _> = serde_json::from_str(json);
+        assert!(result.is_err());
+    }
+}


### PR DESCRIPTION
This PR adds comprehensive test coverage for the Algorithm enum serialization and deserialization functionality. The tests verify:

- Serialization of RSA algorithm to JSON
- Serialization of HMAC algorithm to JSON
- Deserialization of RSA algorithm from JSON
- Deserialization of HMAC algorithm from JSON
- Error handling for invalid algorithm values

The test suite ensures that the Algorithm enum can be properly serialized to and deserialized from JSON format, maintaining data integrity and proper error handling for invalid inputs.

Testing:

- Added unit tests for both serialization and deserialization
- Verified error handling for invalid algorithm values
- All tests are passing

This change improves the reliability of the codebase by ensuring the Algorithm enum's serialization behavior is well-tested and documented.

Closes #34 
