### PR TITLE
Refactor: Remove replace Method and Improve Error Handling in AccessToken Conversion

### DIFF
--- a/src/models/access_token.rs
+++ b/src/models/access_token.rs
@@ -28,13 +28,13 @@ pub struct AccessToken {
 
 impl From<AccessToken> for Document {
     fn from(value: AccessToken) -> Self {
-        to_document(&value).unwrap()
+        to_document(&value).expect("Failed to convert AccessToken to Document")
     }
 }
 
 impl From<Document> for AccessToken {
     fn from(value: Document) -> Self {
-        from_document(value.clone()).unwrap()
+        from_document(value.clone()).expect("Failed to convert Document to AccessToken")
     }
 }
 
@@ -106,6 +106,7 @@ impl From<AccessTokenSortableFields> for String {
 mod tests {
     use super::*;
     use chrono::Duration;
+    use mongodb::bson::doc;
 
     #[test]
     fn test_access_token_creation() {
@@ -144,6 +145,20 @@ mod tests {
         assert_eq!(token.key, converted.key);
         assert_eq!(token.algorithm, converted.algorithm);
         assert_eq!(token.enabled, converted.enabled);
+    }
+
+    #[test]
+    fn test_access_token_document_conversion_error() {
+        let doc = doc! {
+            "key": "test-key",
+            "expires_at": Utc::now().to_rfc3339(),
+            "created_at": Utc::now().to_rfc3339(),
+            "algorithm": "InvalidAlgorithm", // Invalid algorithm
+            "enabled": true,
+        };
+
+        let result: Result<AccessToken, _> = from_document(doc.clone());
+        assert!(result.is_err(), "Expected conversion to fail due to invalid algorithm");
     }
 
     #[test]

--- a/src/repositories/access_token_repository.rs
+++ b/src/repositories/access_token_repository.rs
@@ -9,7 +9,7 @@ use anyhow::Result;
 use async_trait::async_trait;
 use futures::TryStreamExt;
 use mongodb::bson::uuid::Uuid;
-use mongodb::bson::{doc, to_document};
+use mongodb::bson::{doc, to_document, Document};
 use mongodb::{Collection, Database};
 
 /// Repository for managing AccessToken documents in MongoDB.
@@ -49,22 +49,6 @@ impl Repository<AccessToken> for AccessTokenRepository {
             .find_one(mongodb::bson::doc! { "_id": id })
             .await?;
         Ok(result)
-    }
-
-    async fn replace(&self, id: Uuid, mut item: AccessToken) -> Result<AccessToken, Error> {
-        if item.id.is_none() || item.id.unwrap() != id {
-            item.id = Some(id);
-        }
-        self.collection
-            .update_one(doc! { "_id": id }, doc! { "$set": to_document(&item)? })
-            .await
-            .expect("Failed to update access token");
-        let updated = self
-            .collection
-            .find_one(mongodb::bson::doc! { "_id": id })
-            .await?
-            .unwrap();
-        Ok(updated)
     }
 
     async fn update(&self, id: Uuid, item: Self::UpdatePayload) -> Result<AccessToken, Error> {

--- a/src/repositories/access_token_repository.rs
+++ b/src/repositories/access_token_repository.rs
@@ -9,7 +9,7 @@ use anyhow::Result;
 use async_trait::async_trait;
 use futures::TryStreamExt;
 use mongodb::bson::uuid::Uuid;
-use mongodb::bson::{doc, to_document, Document};
+use mongodb::bson::to_document;
 use mongodb::{Collection, Database};
 
 /// Repository for managing AccessToken documents in MongoDB.

--- a/src/repositories/base.rs
+++ b/src/repositories/base.rs
@@ -16,8 +16,6 @@ pub trait Repository<T: Send + Sync + Serialize + DeserializeOwned + 'static> {
 
     async fn read(&self, id: Uuid) -> Result<Option<T>, Error>;
 
-    async fn replace(&self, id: Uuid, mut item: T) -> Result<T, Error>;
-
     async fn update(&self, id: Uuid, update: Self::UpdatePayload) -> Result<T, Error>;
 
     async fn delete(&self, id: Uuid) -> Result<bool, Error>;

--- a/src/repositories/environment_repository.rs
+++ b/src/repositories/environment_repository.rs
@@ -56,16 +56,6 @@ impl Repository<Environment> for EnvironmentRepository {
         Ok(result)
     }
 
-    async fn replace(&self, id: Uuid, mut item: Environment) -> Result<Environment, Error> {
-        if item.id.is_none() || item.id.unwrap() != id {
-            item.id = Some(id);
-        }
-        self.collection
-            .update_one(doc! { "_id": id }, doc! { "$set": to_document(&item)? })
-            .await?;
-        let updated = self.collection.find_one(doc! { "_id": id }).await?.unwrap();
-        Ok(updated)
-    }
 
     async fn update(&self, id: Uuid, payload: Self::UpdatePayload) -> Result<Environment, Error> {
         let mut document = to_document(&payload)?;

--- a/src/repositories/project_access_repository.rs
+++ b/src/repositories/project_access_repository.rs
@@ -57,16 +57,6 @@ impl Repository<ProjectAccess> for ProjectAccessRepository {
         Ok(result)
     }
 
-    async fn replace(&self, id: Uuid, mut item: ProjectAccess) -> Result<ProjectAccess, Error> {
-        if item.id.is_none() || item.id.unwrap() != id {
-            item.id = Some(id);
-        }
-        self.collection
-            .update_one(doc! { "_id": id }, doc! { "$set": to_document(&item)? })
-            .await?;
-        let updated = self.collection.find_one(doc! { "_id": id }).await?.unwrap();
-        Ok(updated)
-    }
 
     async fn update(&self, id: Uuid, payload: Self::UpdatePayload) -> Result<ProjectAccess, Error> {
         let mut document = to_document(&payload)?;

--- a/src/repositories/project_repository.rs
+++ b/src/repositories/project_repository.rs
@@ -54,16 +54,6 @@ impl Repository<Project> for ProjectRepository {
         Ok(result)
     }
 
-    async fn replace(&self, id: Uuid, mut item: Project) -> Result<Project, Error> {
-        if item.id.is_none() || item.id.unwrap() != id {
-            item.id = Some(id);
-        }
-        self.collection
-            .update_one(doc! { "_id": id }, doc! { "$set": to_document(&item)? })
-            .await?;
-        let updated = self.collection.find_one(doc! { "_id": id }).await?.unwrap();
-        Ok(updated)
-    }
 
     async fn update(&self, id: Uuid, payload: Self::UpdatePayload) -> Result<Project, Error> {
         let mut document = to_document(&payload)?;

--- a/src/repositories/project_scope_repository.rs
+++ b/src/repositories/project_scope_repository.rs
@@ -57,16 +57,6 @@ impl Repository<ProjectScope> for ProjectScopeRepository {
         Ok(result)
     }
 
-    async fn replace(&self, id: Uuid, mut item: ProjectScope) -> Result<ProjectScope, Error> {
-        if item.id.is_none() || item.id.unwrap() != id {
-            item.id = Some(id);
-        }
-        self.collection
-            .update_one(doc! { "_id": id }, doc! { "$set": to_document(&item)? })
-            .await?;
-        let updated = self.collection.find_one(doc! { "_id": id }).await?.unwrap();
-        Ok(updated)
-    }
 
     async fn update(&self, id: Uuid, payload: Self::UpdatePayload) -> Result<ProjectScope, Error> {
         let mut document = to_document(&payload)?;

--- a/src/repositories/service_account_key_repository.rs
+++ b/src/repositories/service_account_key_repository.rs
@@ -49,20 +49,6 @@ impl Repository<ServiceAccountKey> for ServiceAccountKeyRepository {
         Ok(result)
     }
 
-    async fn replace(
-        &self,
-        id: Uuid,
-        mut item: ServiceAccountKey,
-    ) -> Result<ServiceAccountKey, Error> {
-        if item.id.is_none() || item.id.unwrap() != id {
-            item.id = Some(id);
-        }
-        self.collection
-            .update_one(doc! { "_id": id }, doc! { "$set": to_document(&item)? })
-            .await?;
-        let updated = self.collection.find_one(doc! { "_id": id }).await?.unwrap();
-        Ok(updated)
-    }
 
     async fn update(
         &self,

--- a/src/repositories/service_account_repository.rs
+++ b/src/repositories/service_account_repository.rs
@@ -48,17 +48,6 @@ impl Repository<ServiceAccount> for ServiceAccountRepository {
         Ok(result)
     }
 
-    async fn replace(&self, id: Uuid, mut item: ServiceAccount) -> Result<ServiceAccount, Error> {
-        if item.id.is_none() || item.id.unwrap() != id {
-            item.id = Some(id);
-        }
-        self.collection
-            .update_one(doc! { "_id": id }, doc! { "$set": to_document(&item)? })
-            .await?;
-        let updated = self.collection.find_one(doc! { "_id": id }).await?.unwrap();
-        Ok(updated)
-    }
-
     async fn update(
         &self,
         id: Uuid,


### PR DESCRIPTION
This pull request introduces several key changes to the codebase:

1. **Improved Error Handling in AccessToken Conversion**:
   - Updated the `From<AccessToken> for Document` and `From<Document> for AccessToken` implementations to use `expect` instead of `unwrap`. This change provides more informative error messages when conversions fail, aiding in debugging and improving code robustness.

2. **Removal of `replace` Method**:
   - The `replace` method has been removed from several repository implementations, including `AccessTokenRepository`, `EnvironmentRepository`, `ProjectAccessRepository`, `ProjectRepository`, `ProjectScopeRepository`, `ServiceAccountKeyRepository`, and `ServiceAccountRepository`.
   - This method was deemed redundant and its functionality can be achieved through existing `update` methods, simplifying the codebase and reducing maintenance overhead.

3. **Additional Test for Document Conversion**:
   - Added a new test case `test_access_token_document_conversion_error` to ensure that invalid document conversions are properly handled and result in errors. This test specifically checks for invalid algorithm values during conversion.

These changes aim to enhance the maintainability and reliability of the codebase by removing unnecessary code and improving error handling mechanisms.