### PR TITLE
Add Pagination and Filtering to Project Listing Endpoint

### DIFF
--- a/bruno/List Projects.bru
+++ b/bruno/List Projects.bru
@@ -1,0 +1,19 @@
+meta {
+  name: List Projects
+  type: http
+  seq: 4
+}
+
+get {
+  url: http://127.0.0.1:8080/projects/
+  body: none
+  auth: inherit
+}
+
+body:json {
+  {
+    "name": "Something",
+    "description": "definitely something",
+    "enabled": true
+  }
+}

--- a/src/models/pagination.rs
+++ b/src/models/pagination.rs
@@ -1,3 +1,6 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Serialize, Deserialize, Clone, Default)]
 pub struct Pagination {
     pub page: Option<u32>,
     pub limit: Option<u32>,

--- a/src/models/project.rs
+++ b/src/models/project.rs
@@ -44,7 +44,7 @@ pub struct ProjectUpdatePayload {
     pub enabled: Option<bool>,
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone, Default)]
 pub struct ProjectFilter {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,


### PR DESCRIPTION

This pull request introduces enhancements to the project listing endpoint in the `buraq` application. The key changes include:

- **Pagination Support**: Implemented pagination for the `/projects` endpoint, allowing clients to specify `page` and `limit` query parameters to control the number of projects returned per request.
- **Filtering Capability**: Added filtering options to the project listing endpoint, enabling clients to filter projects based on specific criteria such as `name` and `enabled` status.
- **Sorting**: Introduced sorting functionality, allowing projects to be sorted by their ID in ascending order.
- **Test Coverage**: Comprehensive tests have been added to ensure the correct functionality of the new pagination and filtering features. Tests include scenarios for listing projects with and without filters, as well as with pagination.

These enhancements aim to improve the usability and performance of the project listing feature, providing more flexibility and control to the clients consuming the API.

### Changes Made
- Updated `src/routes/project.rs` to include pagination and filtering logic.
- Modified `src/models/pagination.rs` and `src/models/project.rs` to support new features.
- Added new test cases in `src/routes/project.rs` to validate the functionality of pagination and filtering.

### Testing
- Verified that projects can be listed with pagination and filtering through unit tests.
- Ensured that the API responds correctly to various combinations of query parameters.

### Notes
- This PR does not introduce any breaking changes.
- The default behavior remains unchanged when no pagination or filtering parameters are provided.

Please review the changes and provide feedback.