### PR TITLE
Add List Endpoint for Project Scopes with Filtering and Pagination

### DIFF
--- a/src/models/project_scope.rs
+++ b/src/models/project_scope.rs
@@ -47,7 +47,7 @@ pub struct ProjectScopeUpdatePayload {
     pub enabled: Option<bool>,
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone, Default)]
 pub struct ProjectScopeFilter {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub project_id: Option<Uuid>,


### PR DESCRIPTION
This PR introduces a new `list` endpoint for project scopes, allowing users to retrieve a paginated and filtered list of project scopes. The following changes are included:

1. **New Endpoint**:
   - Added a `GET /project-scopes` endpoint to list project scopes with support for filtering and pagination.

2. **Filtering**:
   - Implemented filtering by `name` and `enabled` status using the `ProjectScopeFilter` struct.

3. **Pagination**:
   - Integrated pagination support using the `Pagination` struct to limit the number of results returned.

4. **Sorting**:
   - Added sorting capabilities via `SortBuilder` to order results by `id` in ascending order.

5. **Testing**:
   - Added comprehensive tests for the new endpoint, including:
     - Pagination (`test_list_project_scopes_pagination`).
     - Filtering by name (`test_list_project_scopes_filter_by_name`).
     - Filtering by enabled status (`test_list_project_scopes_filter_by_enabled`).

6. **Miscellaneous**:
   - Updated the `ProjectScopeFilter` struct to derive `Default` for better usability.
   - Modified route configurations in `project_scope.rs` and test files to include the new endpoint.

This enhancement improves the usability of the API by providing a flexible way to query project scopes, making it easier for clients to manage large datasets efficiently.