### PR TITLE
Add List Endpoint for Project Access with Pagination and Filtering

### DIFF
--- a/src/models/project_access.rs
+++ b/src/models/project_access.rs
@@ -49,7 +49,7 @@ pub struct ProjectAccessUpdatePayload {
     pub enabled: Option<bool>,
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone, Default)]
 pub struct ProjectAccessFilter {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub environment_id: Option<Uuid>,

--- a/src/routes/project_access.rs
+++ b/src/routes/project_access.rs
@@ -1,5 +1,7 @@
 use actix_web::{Error, HttpResponse, web};
-use crate::models::project_access::{ProjectAccess, ProjectAccessUpdatePayload};
+use crate::models::project_access::{ProjectAccess, ProjectAccessUpdatePayload, ProjectAccessFilter, ProjectAccessSortableFields};
+use crate::models::pagination::Pagination;
+use crate::models::sort::{SortBuilder, SortDirection};
 use crate::services::project_access_service::ProjectAccessService;
 use crate::config::AppData;
 use mongodb::bson::uuid::Uuid;
@@ -97,10 +99,32 @@ pub async fn delete(
     }
 }
 
+pub async fn list(
+    data: web::Data<AppData>,
+    query: web::Query<ProjectAccessFilter>,
+    pagination: web::Query<Pagination>
+) -> Result<HttpResponse, Error> {
+    let database = data
+        .database
+        .as_ref()
+        .ok_or_else(|| actix_web::error::ErrorInternalServerError("Database not initialized"))?;
+    let service = ProjectAccessService::new(database.clone()).unwrap();
+    let sort = SortBuilder::new().add_sort(ProjectAccessSortableFields::Id, SortDirection::Ascending);
+    let project_accesses = service.find(query.into_inner(), Some(sort), Some(pagination.into_inner())).await;
+
+    match project_accesses {
+        Ok(project_accesses) => Ok(HttpResponse::Ok().json(project_accesses)),
+        Err(e) => {
+            println!("Error listing project accesses: {:?}", e);
+            Err(actix_web::error::ErrorBadRequest(e))
+        }
+    }
+}
+
 pub fn configure_routes(config: &mut web::ServiceConfig) {
     config.service(
         web::scope("/project-access")
-            .service(web::resource("").route(web::post().to(create)))
+            .service(web::resource("").route(web::post().to(create)).route(web::get().to(list)))
             .service(
                 web::resource("/{id}")
                     .route(web::get().to(read))
@@ -129,7 +153,7 @@ mod tests {
         let app = test::init_service(
             App::new().app_data(app_data.clone()).service(
                 web::scope("/project-access")
-                    .service(web::resource("").route(web::post().to(create)))
+                    .service(web::resource("").route(web::post().to(create)).route(web::get().to(list)))
                     .service(
                         web::resource("/{id}")
                             .route(web::get().to(read))
@@ -164,6 +188,185 @@ mod tests {
         assert_eq!(created_access.environment_id, project_access.environment_id);
         assert!(created_access.enabled);
         assert!(created_access.id.is_some());
+
+        // Cleanup
+        cleanup_test_db(db).await.unwrap();
+    }
+
+    #[actix_web::test]
+    async fn test_list_project_access_success() {
+        // Setup
+        let db = setup_test_db("project_access_routes").await.unwrap();
+        let app_data = web::Data::new(AppData {
+            database: Some(std::sync::Arc::new(db.clone())),
+            ..Default::default()
+        });
+
+        let app = test::init_service(
+            App::new().app_data(app_data.clone()).service(
+                web::scope("/project-access")
+                    .service(web::resource("").route(web::post().to(create)).route(web::get().to(list)))
+                    .service(
+                        web::resource("/{id}")
+                            .route(web::get().to(read))
+                            .route(web::patch().to(update))
+                            .route(web::delete().to(delete)),
+                    ),
+            ),
+        )
+        .await;
+
+        // Create multiple project accesses
+        for i in 1..=3 {
+            let project_access = ProjectAccess {
+                id: None,
+                name: format!("Test Access {}", i),
+                environment_id: Uuid::new(),
+                service_account_id: Uuid::new(),
+                project_scopes: vec![Uuid::new()],
+                enabled: true,
+                created_at: Some(Utc::now()),
+                updated_at: Some(Utc::now()),
+            };
+
+            let resp = test::TestRequest::post()
+                .uri("/project-access")
+                .set_json(&project_access)
+                .send_request(&app)
+                .await;
+
+            assert!(resp.status().is_success());
+        }
+
+        // Test list
+        let resp = test::TestRequest::get()
+            .uri("/project-access")
+            .send_request(&app)
+            .await;
+
+        assert!(resp.status().is_success());
+        let project_accesses: Vec<ProjectAccess> = test::read_body_json(resp).await;
+        assert_eq!(project_accesses.len(), 3);
+
+        // Cleanup
+        cleanup_test_db(db).await.unwrap();
+    }
+
+    #[actix_web::test]
+    async fn test_list_project_access_with_pagination() {
+        // Setup
+        let db = setup_test_db("project_access_routes").await.unwrap();
+        let app_data = web::Data::new(AppData {
+            database: Some(std::sync::Arc::new(db.clone())),
+            ..Default::default()
+        });
+
+        let app = test::init_service(
+            App::new().app_data(app_data.clone()).service(
+                web::scope("/project-access")
+                    .service(web::resource("").route(web::post().to(create)).route(web::get().to(list)))
+                    .service(
+                        web::resource("/{id}")
+                            .route(web::get().to(read))
+                            .route(web::patch().to(update))
+                            .route(web::delete().to(delete)),
+                    ),
+            ),
+        )
+        .await;
+
+        // Create multiple project accesses
+        for i in 1..=5 {
+            let project_access = ProjectAccess {
+                id: None,
+                name: format!("Test Access {}", i),
+                environment_id: Uuid::new(),
+                service_account_id: Uuid::new(),
+                project_scopes: vec![Uuid::new()],
+                enabled: true,
+                created_at: Some(Utc::now()),
+                updated_at: Some(Utc::now()),
+            };
+
+            let resp = test::TestRequest::post()
+                .uri("/project-access")
+                .set_json(&project_access)
+                .send_request(&app)
+                .await;
+
+            assert!(resp.status().is_success());
+        }
+
+        // Test pagination
+        let resp = test::TestRequest::get()
+            .uri("/project-access?page=1&limit=2")
+            .send_request(&app)
+            .await;
+
+        assert!(resp.status().is_success());
+        let project_accesses: Vec<ProjectAccess> = test::read_body_json(resp).await;
+        assert_eq!(project_accesses.len(), 2);
+
+        // Cleanup
+        cleanup_test_db(db).await.unwrap();
+    }
+
+    #[actix_web::test]
+    async fn test_list_project_access_with_filters() {
+        // Setup
+        let db = setup_test_db("project_access_routes").await.unwrap();
+        let app_data = web::Data::new(AppData {
+            database: Some(std::sync::Arc::new(db.clone())),
+            ..Default::default()
+        });
+
+        let app = test::init_service(
+            App::new().app_data(app_data.clone()).service(
+                web::scope("/project-access")
+                    .service(web::resource("").route(web::post().to(create)).route(web::get().to(list)))
+                    .service(
+                        web::resource("/{id}")
+                            .route(web::get().to(read))
+                            .route(web::patch().to(update))
+                            .route(web::delete().to(delete)),
+                    ),
+            ),
+        )
+        .await;
+
+        // Create multiple project accesses
+        let env_id = Uuid::new();
+        for i in 1..=3 {
+            let project_access = ProjectAccess {
+                id: None,
+                name: format!("Test Access {}", i),
+                environment_id: if i == 1 { env_id } else { Uuid::new() },
+                service_account_id: Uuid::new(),
+                project_scopes: vec![Uuid::new()],
+                enabled: true,
+                created_at: Some(Utc::now()),
+                updated_at: Some(Utc::now()),
+            };
+
+            let resp = test::TestRequest::post()
+                .uri("/project-access")
+                .set_json(&project_access)
+                .send_request(&app)
+                .await;
+
+            assert!(resp.status().is_success());
+        }
+
+        // Test filters
+        let resp = test::TestRequest::get()
+            .uri(&format!("/project-access?environment_id={}", env_id))
+            .send_request(&app)
+            .await;
+
+        assert!(resp.status().is_success());
+        let project_accesses: Vec<ProjectAccess> = test::read_body_json(resp).await;
+        assert_eq!(project_accesses.len(), 1);
+        assert_eq!(project_accesses[0].environment_id, env_id);
 
         // Cleanup
         cleanup_test_db(db).await.unwrap();


### PR DESCRIPTION
This PR introduces a new endpoint `/project-access` with a `GET` method to list project accesses. The endpoint supports:
- **Pagination**: Allows fetching results in chunks using `page` and `limit` query parameters.
- **Filtering**: Supports filtering by `environment_id` and other fields via the `ProjectAccessFilter` struct.
- **Sorting**: Results can be sorted by `id` in ascending order.

#### Key Changes:
1. Added `list` function in `src/routes/project_access.rs` to handle the new endpoint.
2. Updated `ProjectAccessFilter` in `src/models/project_access.rs` to derive `Default` for easier use in query parameters.
3. Extended the test suite to cover the new functionality, including:
   - Basic listing of project accesses.
   - Pagination.
   - Filtering by `environment_id`.

#### Testing:
- Added unit tests for the new endpoint to ensure correctness:
  - `test_list_project_access_success`: Verifies basic listing.
  - `test_list_project_access_with_pagination`: Tests pagination.
  - `test_list_project_access_with_filters`: Tests filtering.

#### Impact:
- No breaking changes; existing endpoints remain unchanged.
- Improves usability by allowing clients to fetch and filter project accesses efficiently.