### PR TITLE
Add List Endpoint for Service Account Keys with Filtering, Sorting, and Pagination

### DIFF
--- a/src/models/service_account_key.rs
+++ b/src/models/service_account_key.rs
@@ -51,7 +51,7 @@ pub struct ServiceAccountKeyUpdatePayload {
     pub enabled: Option<bool>,
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone, Default)]
 pub struct ServiceAccountKeyFilter {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub service_account_id: Option<Uuid>,


### PR DESCRIPTION
This PR introduces a new endpoint `/service_account_keys` with a `GET` method to list service account keys. The endpoint supports:
- **Filtering**: Allows filtering by `service_account_id` and `enabled` status.
- **Sorting**: Supports sorting by `id` in ascending order.
- **Pagination**: Implements pagination to limit the number of results returned.

#### Key Changes:
1. **Model Update**:
   - Added `Default` derive for `ServiceAccountKeyFilter` to simplify handling optional filters.

2. **Route Update**:
   - Added a new `list` function in `src/routes/service_account_key.rs` to handle the `GET` request.
   - Updated the route configuration to include the new endpoint.

3. **Testing**:
   - Added comprehensive tests for the new endpoint, covering:
     - Basic listing of keys.
     - Pagination functionality.
     - Filtering by `enabled` status.

#### Impact:
- Enhances the API by providing a way to query service account keys with flexibility.
- Improves usability for clients needing to fetch subsets of keys based on specific criteria.

#### Notes:
- The endpoint is backward-compatible with existing functionality.
- The implementation leverages the existing `ServiceAccountKeyService` for database operations.