### PR TITLE
Add MongoDB Indexes to AccessTokenRepository for Query Optimization

### DIFF
--- a/src/repositories/access_token_repository.rs
+++ b/src/repositories/access_token_repository.rs
@@ -11,6 +11,8 @@ use futures::TryStreamExt;
 use mongodb::bson::uuid::Uuid;
 use mongodb::bson::to_document;
 use mongodb::{Collection, Database};
+use mongodb::options::IndexOptions;
+use mongodb::IndexModel;
 
 /// Repository for managing AccessToken documents in MongoDB.
 ///
@@ -22,6 +24,7 @@ pub struct AccessTokenRepository {
 impl AccessTokenRepository {
     pub fn new(database: Database) -> Result<Self, anyhow::Error> {
         let collection = database.collection::<AccessToken>("access_tokens");
+
         Ok(Self { collection })
     }
 }
@@ -40,6 +43,27 @@ impl Repository<AccessToken> for AccessTokenRepository {
             .insert_one(&item)
             .await
             .expect("Failed to create access token");
+
+
+        self.collection.create_index(
+            IndexModel::builder()
+                .keys(mongodb::bson::doc! { "project_access_id": 1, "algorithm": 1, "expires_at": 1 })
+                .build()
+        ).await.expect("Failed to create index on project_access_id, algorithm, expires_at");
+
+        self.collection.create_index(
+            IndexModel::builder()
+                .keys(mongodb::bson::doc! { "project_access_id": 1, "algorithm": 1, "active": 1 })
+                .build()
+        ).await.expect("Failed to create index on project_access_id, algorithm, active");
+
+        self.collection.create_index(
+            IndexModel::builder()
+                .keys(mongodb::bson::doc! { "project_access_id": 1, "enabled": 1 })
+                .build()
+        ).await.expect("Failed to create index on project_access_id, enabled");
+
+
         Ok(item)
     }
 


### PR DESCRIPTION
This PR adds three MongoDB indexes to the `AccessTokenRepository` to optimize query performance for common access token operations:

1. Compound index on `(project_access_id, algorithm, expires_at)` - Optimizes queries that filter access tokens by project access ID, algorithm, and expiration time
2. Compound index on `(project_access_id, algorithm, active)` - Improves performance for queries that check active tokens for a specific project and algorithm
3. Compound index on `(project_access_id, enabled)` - Enhances queries that filter tokens by project access ID and enabled status

These indexes will help improve the performance of token-related operations, particularly when querying for valid, active tokens within a project context.

## Changes
- Added MongoDB index creation in `AccessTokenRepository::create()` method
- Imported required MongoDB index-related types (`IndexOptions`, `IndexModel`)
- Indexes are created after inserting a new access token
