### PR TITLE
Add MongoDB indexes for Environment collection

### DIFF
--- a/src/utils/database.rs
+++ b/src/utils/database.rs
@@ -2,7 +2,10 @@ use mongodb::{Client, Database};
 use anyhow::Error;
 use std::sync::Arc;
 
-use crate::repositories::access_token_repository::AccessTokenRepository;
+use crate::repositories::{
+    access_token_repository::AccessTokenRepository,
+    environment_repository::EnvironmentRepository,
+};
 
 pub async fn create_database_client(database_uri: &str) -> Result<Arc<Client>, anyhow::Error> {
     let client = mongodb::Client::with_uri_str(&database_uri)
@@ -13,8 +16,8 @@ pub async fn create_database_client(database_uri: &str) -> Result<Arc<Client>, a
 }
 
 pub async fn setup_database(database: Database) -> Result<(), Error> {
-    AccessTokenRepository::new(database).unwrap().ensure_indexes().await?;
-
+    AccessTokenRepository::new(database.clone()).unwrap().ensure_indexes().await?;
+    EnvironmentRepository::new(database).unwrap().ensure_indexes().await?;
     Ok(())
 }
 


### PR DESCRIPTION
This PR adds necessary MongoDB indexes for the Environment collection to improve query performance and ensure data integrity. The changes include:

- Added a unique compound index on `project_id` and `name` fields to prevent duplicate environment names within the same project
- Added a compound index on `project_id` and `enabled` fields to optimize queries filtering environments by project and status
- Integrated Environment repository index creation into the database setup process

## Technical Details
- Created `ensure_indexes()` method in `EnvironmentRepository` to handle index creation
- Updated `setup_database()` to initialize Environment repository indexes alongside AccessToken repository indexes
- Added required MongoDB imports for index creation functionality
