### PR TITLE
Add MongoDB indexes for ProjectAccess collection

### DIFF
--- a/src/utils/database.rs
+++ b/src/utils/database.rs
@@ -5,6 +5,7 @@ use std::sync::Arc;
 use crate::repositories::{
     access_token_repository::AccessTokenRepository,
     environment_repository::EnvironmentRepository,
+    project_access_repository::ProjectAccessRepository,
 };
 
 pub async fn create_database_client(database_uri: &str) -> Result<Arc<Client>, anyhow::Error> {
@@ -17,7 +18,8 @@ pub async fn create_database_client(database_uri: &str) -> Result<Arc<Client>, a
 
 pub async fn setup_database(database: Database) -> Result<(), Error> {
     AccessTokenRepository::new(database.clone()).unwrap().ensure_indexes().await?;
-    EnvironmentRepository::new(database).unwrap().ensure_indexes().await?;
+    EnvironmentRepository::new(database.clone()).unwrap().ensure_indexes().await?;
+    ProjectAccessRepository::new(database).unwrap().ensure_indexes().await?;
     Ok(())
 }
 


### PR DESCRIPTION
This PR adds necessary MongoDB indexes for the `ProjectAccess` collection to improve query performance and ensure data integrity. The changes include:

- Added a compound unique index on `(service_account_id, environment_id)` to prevent duplicate access entries
- Added an index on `project_scopes` field for faster querying of project scope-based operations
- Added an index on `enabled` field to optimize filtering of active/inactive access entries
- Integrated `ProjectAccessRepository` into the database setup process

## Technical Details
- Created `ensure_indexes()` method in `ProjectAccessRepository` to manage collection indexes
- Updated `setup_database()` function to initialize indexes for the new repository
- Added necessary MongoDB imports for index creation
