### PR TITLE
Add MongoDB Indexes for Project Collection

### DIFF
--- a/src/utils/database.rs
+++ b/src/utils/database.rs
@@ -6,6 +6,7 @@ use crate::repositories::{
     access_token_repository::AccessTokenRepository,
     environment_repository::EnvironmentRepository,
     project_access_repository::ProjectAccessRepository,
+    project_repository::ProjectRepository,
 };
 
 pub async fn create_database_client(database_uri: &str) -> Result<Arc<Client>, anyhow::Error> {
@@ -19,7 +20,8 @@ pub async fn create_database_client(database_uri: &str) -> Result<Arc<Client>, a
 pub async fn setup_database(database: Database) -> Result<(), Error> {
     AccessTokenRepository::new(database.clone()).unwrap().ensure_indexes().await?;
     EnvironmentRepository::new(database.clone()).unwrap().ensure_indexes().await?;
-    ProjectAccessRepository::new(database).unwrap().ensure_indexes().await?;
+    ProjectAccessRepository::new(database.clone()).unwrap().ensure_indexes().await?;
+    ProjectRepository::new(database).unwrap().ensure_indexes().await?;
     Ok(())
 }
 


### PR DESCRIPTION
This PR adds MongoDB indexes to the project collection to improve query performance and ensure data integrity. The changes include:

- Added a unique index on the `name` field to prevent duplicate project names
- Added an index on the `enabled` field to optimize queries filtering by project status
- Updated database setup to ensure project indexes are created during initialization
- Added index creation calls in all project repository tests

## Changes
- Added `ensure_indexes()` method to `ProjectRepository`
- Updated `setup_database()` to initialize project indexes
- Modified test cases to call `ensure_indexes()` before running tests

