### PR TITLE
Add MongoDB indexes for ServiceAccountKey collection

### DIFF
--- a/src/repositories/service_account_key_repository.rs
+++ b/src/repositories/service_account_key_repository.rs
@@ -10,11 +10,11 @@ use anyhow::Result;
 use async_trait::async_trait;
 use chrono::Utc;
 use futures::TryStreamExt;
+use mongodb::IndexModel;
 use mongodb::bson::uuid::Uuid;
 use mongodb::bson::{Bson, doc, to_document};
-use mongodb::{Collection, Database};
-use mongodb::IndexModel;
 use mongodb::options::IndexOptions;
+use mongodb::{Collection, Database};
 
 /// Repository for managing ServiceAccountKey documents in MongoDB.
 ///
@@ -138,7 +138,9 @@ mod tests {
         let db = setup_test_db("service_account_key").await.unwrap();
         let repo =
             ServiceAccountKeyRepository::new(db.clone()).expect("Failed to create repository");
-        repo.ensure_indexes().await.expect("Failed to create indexes");
+        repo.ensure_indexes()
+            .await
+            .expect("Failed to create indexes");
         (repo, db)
     }
 

--- a/src/repositories/service_account_key_repository.rs
+++ b/src/repositories/service_account_key_repository.rs
@@ -13,6 +13,8 @@ use futures::TryStreamExt;
 use mongodb::bson::uuid::Uuid;
 use mongodb::bson::{Bson, doc, to_document};
 use mongodb::{Collection, Database};
+use mongodb::IndexModel;
+use mongodb::options::IndexOptions;
 
 /// Repository for managing ServiceAccountKey documents in MongoDB.
 ///
@@ -25,6 +27,25 @@ impl ServiceAccountKeyRepository {
     pub fn new(database: Database) -> Result<Self, anyhow::Error> {
         let collection = database.collection::<ServiceAccountKey>("service_account_keys");
         Ok(Self { collection })
+    }
+
+    pub async fn ensure_indexes(&self) -> Result<()> {
+        let unique_options = IndexOptions::builder().unique(true).build();
+        let non_unique_options = IndexOptions::builder().unique(false).build();
+
+        let unique_index = IndexModel::builder()
+            .keys(doc! { "service_account_id": 1, "algorithm": 1 })
+            .options(unique_options)
+            .build();
+
+        let non_unique_index = IndexModel::builder()
+            .keys(doc! { "service_account_id": 1, "expires_at": 1, "enabled": 1 })
+            .options(non_unique_options)
+            .build();
+
+        self.collection.create_index(unique_index).await?;
+        self.collection.create_index(non_unique_index).await?;
+        Ok(())
     }
 }
 
@@ -117,6 +138,7 @@ mod tests {
         let db = setup_test_db("service_account_key").await.unwrap();
         let repo =
             ServiceAccountKeyRepository::new(db.clone()).expect("Failed to create repository");
+        repo.ensure_indexes().await.expect("Failed to create indexes");
         (repo, db)
     }
 

--- a/src/utils/database.rs
+++ b/src/utils/database.rs
@@ -5,7 +5,8 @@ use std::sync::Arc;
 use crate::repositories::{
     access_token_repository::AccessTokenRepository, environment_repository::EnvironmentRepository,
     project_access_repository::ProjectAccessRepository, project_repository::ProjectRepository,
-    project_scope_repository::ProjectScopeRepository, service_account_key_repository::ServiceAccountKeyRepository,
+    project_scope_repository::ProjectScopeRepository,
+    service_account_key_repository::ServiceAccountKeyRepository,
 };
 
 pub async fn create_database_client(database_uri: &str) -> Result<Arc<Client>, anyhow::Error> {

--- a/src/utils/database.rs
+++ b/src/utils/database.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 use crate::repositories::{
     access_token_repository::AccessTokenRepository, environment_repository::EnvironmentRepository,
     project_access_repository::ProjectAccessRepository, project_repository::ProjectRepository,
-    project_scope_repository::ProjectScopeRepository,
+    project_scope_repository::ProjectScopeRepository, service_account_key_repository::ServiceAccountKeyRepository,
 };
 
 pub async fn create_database_client(database_uri: &str) -> Result<Arc<Client>, anyhow::Error> {
@@ -33,7 +33,11 @@ pub async fn setup_database(database: Database) -> Result<(), Error> {
         .unwrap()
         .ensure_indexes()
         .await?;
-    ProjectScopeRepository::new(database)
+    ProjectScopeRepository::new(database.clone())
+        .unwrap()
+        .ensure_indexes()
+        .await?;
+    ServiceAccountKeyRepository::new(database)
         .unwrap()
         .ensure_indexes()
         .await?;


### PR DESCRIPTION
This PR adds MongoDB indexes to optimize query performance for the ServiceAccountKey collection. The changes include:

- Added a unique compound index on `service_account_id` and `algorithm` fields
- Added a non-unique compound index on `service_account_id`, `expires_at`, and `enabled` fields
- Integrated ServiceAccountKeyRepository index creation into the database setup process

## Technical Details
- Created `ensure_indexes()` method in ServiceAccountKeyRepository to manage index creation
- Added unique index to prevent duplicate key algorithms per service account
- Added non-unique index to optimize queries filtering by service account, expiration, and enabled status
- Updated database setup to include ServiceAccountKeyRepository index initialization

## Testing
- Added index creation to the test setup to ensure indexes are properly created in test environment