### PR TITLE
Add unique indexes for ServiceAccount collection

### DIFF
--- a/src/utils/database.rs
+++ b/src/utils/database.rs
@@ -7,6 +7,7 @@ use crate::repositories::{
     project_access_repository::ProjectAccessRepository, project_repository::ProjectRepository,
     project_scope_repository::ProjectScopeRepository,
     service_account_key_repository::ServiceAccountKeyRepository,
+    service_account_repository::ServiceAccountRepository,
 };
 
 pub async fn create_database_client(database_uri: &str) -> Result<Arc<Client>, anyhow::Error> {
@@ -38,7 +39,11 @@ pub async fn setup_database(database: Database) -> Result<(), Error> {
         .unwrap()
         .ensure_indexes()
         .await?;
-    ServiceAccountKeyRepository::new(database)
+    ServiceAccountKeyRepository::new(database.clone())
+        .unwrap()
+        .ensure_indexes()
+        .await?;
+    ServiceAccountRepository::new(database.clone())
         .unwrap()
         .ensure_indexes()
         .await?;


### PR DESCRIPTION
This PR adds unique indexes to the `service_accounts` collection to ensure data integrity and improve query performance. The changes include:

- Added unique index on the `email` field to prevent duplicate service account emails
- Added unique index on the `user` field to ensure one-to-one relationship between users and service accounts
- Updated database setup to ensure indexes are created during application initialization
- Added index creation to test setup to maintain consistency in test environment

## Technical Details
- Implemented `ensure_indexes()` method in `ServiceAccountRepository`
- Updated `setup_database()` to include service account index creation
- Modified test setup to create indexes before running tests

## Testing
- All existing tests should continue to pass
- New indexes will be automatically created during application startup
- Test environment will have consistent index setup

## Impact
These changes will prevent duplicate service accounts and improve query performance when searching by email or user ID.