### PR TITLE
Refactor repository test setup to use consistent pattern and improve test organization

### DIFF
--- a/src/repositories/access_token_repository.rs
+++ b/src/repositories/access_token_repository.rs
@@ -154,6 +154,7 @@ mod tests {
     async fn setup() -> (AccessTokenRepository, Database) {
         let db = setup_test_db("access_token").await.unwrap();
         let repo = AccessTokenRepository::new(db.clone()).expect("Failed to create repository");
+        repo.ensure_indexes().await.expect("Failed to create indexes");
         (repo, db)
     }
 

--- a/src/repositories/access_token_repository.rs
+++ b/src/repositories/access_token_repository.rs
@@ -154,7 +154,9 @@ mod tests {
     async fn setup() -> (AccessTokenRepository, Database) {
         let db = setup_test_db("access_token").await.unwrap();
         let repo = AccessTokenRepository::new(db.clone()).expect("Failed to create repository");
-        repo.ensure_indexes().await.expect("Failed to create indexes");
+        repo.ensure_indexes()
+            .await
+            .expect("Failed to create indexes");
         (repo, db)
     }
 

--- a/src/repositories/environment_repository.rs
+++ b/src/repositories/environment_repository.rs
@@ -143,9 +143,11 @@ mod tests {
     async fn setup() -> (EnvironmentRepository, Database) {
         let db = setup_test_db("environment").await.unwrap();
         let repo = EnvironmentRepository::new(db.clone()).expect("Failed to create repository");
-        repo.ensure_indexes().await.expect("Failed to create indexes");
+        repo.ensure_indexes()
+            .await
+            .expect("Failed to create indexes");
         (repo, db)
-    }    
+    }
 
     #[tokio::test]
     async fn test_create_environment() -> Result<()> {

--- a/src/repositories/environment_repository.rs
+++ b/src/repositories/environment_repository.rs
@@ -139,25 +139,17 @@ impl Repository<Environment> for EnvironmentRepository {
 mod tests {
     use super::*;
     use crate::test_utils::{cleanup_test_db, setup_test_db};
-    use mongodb::IndexModel;
-    use mongodb::options::IndexOptions;
 
-    async fn ensure_unique_index(db: &Database) -> Result<()> {
-        let collection = db.collection::<Environment>("environments");
-        let options = IndexOptions::builder().unique(true).build();
-        let index = IndexModel::builder()
-            .keys(doc! { "project_id": 1, "name": 1 })
-            .options(options)
-            .build();
-        collection.create_index(index).await?;
-        Ok(())
-    }
+    async fn setup() -> (EnvironmentRepository, Database) {
+        let db = setup_test_db("environment").await.unwrap();
+        let repo = EnvironmentRepository::new(db.clone()).expect("Failed to create repository");
+        repo.ensure_indexes().await.expect("Failed to create indexes");
+        (repo, db)
+    }    
 
     #[tokio::test]
     async fn test_create_environment() -> Result<()> {
-        let db = setup_test_db("environment").await?;
-        ensure_unique_index(&db).await?;
-        let repo = EnvironmentRepository::new(db.clone())?;
+        let (repo, db) = setup().await;
 
         let project_id = Uuid::new();
         let environment = Environment {
@@ -180,9 +172,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_create_duplicate_environment() -> Result<()> {
-        let db = setup_test_db("environment").await?;
-        ensure_unique_index(&db).await?;
-        let repo = EnvironmentRepository::new(db.clone())?;
+        let (repo, db) = setup().await;
 
         let project_id = Uuid::new();
         let name = "Test Environment".to_string();
@@ -217,9 +207,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_read_environment() -> Result<()> {
-        let db = setup_test_db("environment").await?;
-        ensure_unique_index(&db).await?;
-        let repo = EnvironmentRepository::new(db.clone())?;
+        let (repo, db) = setup().await;
 
         let project_id = Uuid::new();
         let environment = Environment {
@@ -246,9 +234,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_update_environment() -> Result<()> {
-        let db = setup_test_db("environment").await?;
-        ensure_unique_index(&db).await?;
-        let repo = EnvironmentRepository::new(db.clone())?;
+        let (repo, db) = setup().await;
 
         let project_id = Uuid::new();
         let environment = Environment {
@@ -279,9 +265,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_delete_environment() -> Result<()> {
-        let db = setup_test_db("environment").await?;
-        ensure_unique_index(&db).await?;
-        let repo = EnvironmentRepository::new(db.clone())?;
+        let (repo, db) = setup().await;
 
         let project_id = Uuid::new();
         let environment = Environment {
@@ -307,9 +291,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_find_environments() -> Result<()> {
-        let db = setup_test_db("environment").await?;
-        ensure_unique_index(&db).await?;
-        let repo = EnvironmentRepository::new(db.clone())?;
+        let (repo, db) = setup().await;
 
         let project_id = Uuid::new();
         let environment1 = Environment {
@@ -387,9 +369,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_environment_filter_by_project_id() -> Result<()> {
-        let db = setup_test_db("environment").await?;
-        ensure_unique_index(&db).await?;
-        let repo = EnvironmentRepository::new(db.clone())?;
+        let (repo, db) = setup().await;
 
         let project_id = Uuid::new();
         let environment = Environment {
@@ -418,9 +398,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_environment_filter_by_name() -> Result<()> {
-        let db = setup_test_db("environment").await?;
-        ensure_unique_index(&db).await?;
-        let repo = EnvironmentRepository::new(db.clone())?;
+        let (repo, db) = setup().await;
 
         let environment = Environment {
             id: None,
@@ -448,9 +426,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_environment_filter_by_enabled() -> Result<()> {
-        let db = setup_test_db("environment").await?;
-        ensure_unique_index(&db).await?;
-        let repo = EnvironmentRepository::new(db.clone())?;
+        let (repo, db) = setup().await;
 
         let environment = Environment {
             id: None,

--- a/src/repositories/project_access_repository.rs
+++ b/src/repositories/project_access_repository.rs
@@ -156,7 +156,9 @@ mod tests {
     async fn setup() -> (ProjectAccessRepository, Database) {
         let db = setup_test_db("project_access").await.unwrap();
         let repo = ProjectAccessRepository::new(db.clone()).expect("Failed to create repository");
-        repo.ensure_indexes().await.expect("Failed to create indexes");
+        repo.ensure_indexes()
+            .await
+            .expect("Failed to create indexes");
         (repo, db)
     }
 

--- a/src/repositories/project_access_repository.rs
+++ b/src/repositories/project_access_repository.rs
@@ -156,6 +156,7 @@ mod tests {
     async fn setup() -> (ProjectAccessRepository, Database) {
         let db = setup_test_db("project_access").await.unwrap();
         let repo = ProjectAccessRepository::new(db.clone()).expect("Failed to create repository");
+        repo.ensure_indexes().await.expect("Failed to create indexes");
         (repo, db)
     }
 
@@ -290,13 +291,14 @@ mod tests {
     async fn test_find_project_access() -> Result<()> {
         let (repo, db) = setup().await;
         let environment_id = Uuid::new();
-        let service_account_id = Some(Uuid::new());
+        let service_account_id1 = Some(Uuid::new());
+        let service_account_id2 = Some(Uuid::new());
 
         let access1 = ProjectAccess {
             id: None,
             name: "Access 1".to_string(),
             environment_id,
-            service_account_id,
+            service_account_id: service_account_id1,
             project_scopes: vec![Uuid::new()],
             enabled: true,
             created_at: Some(Utc::now()),
@@ -306,7 +308,7 @@ mod tests {
             id: None,
             name: "Access 2".to_string(),
             environment_id,
-            service_account_id,
+            service_account_id: service_account_id2,
             project_scopes: vec![Uuid::new()],
             enabled: false,
             created_at: Some(Utc::now()),

--- a/src/repositories/project_repository.rs
+++ b/src/repositories/project_repository.rs
@@ -138,7 +138,9 @@ mod tests {
     async fn setup() -> (ProjectRepository, Database) {
         let db = setup_test_db("project").await.unwrap();
         let repo = ProjectRepository::new(db.clone()).expect("Failed to create repository");
-        repo.ensure_indexes().await.expect("Failed to create indexes");
+        repo.ensure_indexes()
+            .await
+            .expect("Failed to create indexes");
         (repo, db)
     }
 

--- a/src/repositories/project_repository.rs
+++ b/src/repositories/project_repository.rs
@@ -135,6 +135,13 @@ mod tests {
     use crate::test_utils::{cleanup_test_db, setup_test_db};
     use chrono::Utc;
 
+    async fn setup() -> (ProjectRepository, Database) {
+        let db = setup_test_db("project").await.unwrap();
+        let repo = ProjectRepository::new(db.clone()).expect("Failed to create repository");
+        repo.ensure_indexes().await.expect("Failed to create indexes");
+        (repo, db)
+    }
+
     async fn create_test_project(repo: &ProjectRepository) -> Result<Project> {
         let project = Project {
             id: None,
@@ -149,9 +156,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_create_project() -> Result<()> {
-        let db = setup_test_db("project").await?;
-        let repo = ProjectRepository::new(db.clone())?;
-        repo.ensure_indexes().await?;
+        let (repo, db) = setup().await;
 
         let created = create_test_project(&repo).await?;
 
@@ -168,9 +173,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_read_project() -> Result<()> {
-        let db = setup_test_db("project").await?;
-        let repo = ProjectRepository::new(db.clone())?;
-        repo.ensure_indexes().await?;
+        let (repo, db) = setup().await;
 
         let created = create_test_project(&repo).await?;
         let read = repo.read(created.id.unwrap()).await?;
@@ -194,9 +197,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_update_project() -> Result<()> {
-        let db = setup_test_db("project").await?;
-        let repo = ProjectRepository::new(db.clone())?;
-        repo.ensure_indexes().await?;
+        let (repo, db) = setup().await;
 
         let created = create_test_project(&repo).await?;
         let project_id = created.id.unwrap();
@@ -235,9 +236,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_delete_project() -> Result<()> {
-        let db = setup_test_db("project").await?;
-        let repo = ProjectRepository::new(db.clone())?;
-        repo.ensure_indexes().await?;
+        let (repo, db) = setup().await;
 
         let created = create_test_project(&repo).await?;
         let project_id = created.id.unwrap();
@@ -260,9 +259,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_find_projects() -> Result<()> {
-        let db = setup_test_db("project").await?;
-        let repo = ProjectRepository::new(db.clone())?;
-        repo.ensure_indexes().await?;
+        let (repo, db) = setup().await;
 
         // Create multiple test projects
         let project1 = Project {

--- a/src/repositories/project_scope_repository.rs
+++ b/src/repositories/project_scope_repository.rs
@@ -145,7 +145,9 @@ mod tests {
     async fn setup() -> (ProjectScopeRepository, Database) {
         let db = setup_test_db("project_scope").await.unwrap();
         let repo = ProjectScopeRepository::new(db.clone()).expect("Failed to create repository");
-        repo.ensure_indexes().await.expect("Failed to create indexes");
+        repo.ensure_indexes()
+            .await
+            .expect("Failed to create indexes");
         (repo, db)
     }
 

--- a/src/repositories/project_scope_repository.rs
+++ b/src/repositories/project_scope_repository.rs
@@ -145,6 +145,7 @@ mod tests {
     async fn setup() -> (ProjectScopeRepository, Database) {
         let db = setup_test_db("project_scope").await.unwrap();
         let repo = ProjectScopeRepository::new(db.clone()).expect("Failed to create repository");
+        repo.ensure_indexes().await.expect("Failed to create indexes");
         (repo, db)
     }
 


### PR DESCRIPTION
## Changes
- Introduced consistent `setup()` helper function across repository test modules
- Moved index creation into `ensure_indexes()` calls within setup functions
- Removed duplicate index creation code from individual tests
- Improved test organization by centralizing common setup logic
- Fixed test data in `project_access_repository.rs` to use distinct service account IDs

## Affected Files
- `src/repositories/access_token_repository.rs`
- `src/repositories/environment_repository.rs`
- `src/repositories/project_access_repository.rs`
- `src/repositories/project_repository.rs`
- `src/repositories/project_scope_repository.rs`

## Testing
- All existing tests have been updated to use the new setup pattern
- Test functionality remains unchanged, only the setup code has been refactored
- Index creation is now handled consistently across all repository tests

## Impact
This refactoring improves code maintainability by:
- Reducing code duplication
- Standardizing test setup patterns
- Making index creation more explicit and consistent
- Simplifying individual test cases by moving common setup logic to helper functions