### PR TITLE
feat: Add Windsurf rules configuration

### DIFF
--- a/.codeium/windsurf/mcp_config.json
+++ b/.codeium/windsurf/mcp_config.json
@@ -1,0 +1,41 @@
+{
+  "mcpServers": {
+    "github": {
+      "command": "docker",
+      "args": [
+        "run",
+        "-i",
+        "--rm",
+        "-e",
+        "GITHUB_PERSONAL_ACCESS_TOKEN",
+        "-e",
+        "GITHUB_HOST",
+        "ghcr.io/github/github-mcp-server"
+      ],
+      "env": {
+        "GITHUB_HOST": "https://github.com"
+      }
+    },
+    "fetch": {
+      "command": "docker",
+      "args": [
+        "run",
+        "-i",
+        "--rm",
+        "mcp/fetch"
+      ]
+    },
+    "filesystem": {
+      "command": "docker",
+      "args": [
+        "run",
+        "-i",
+        "--rm",
+        "-v",
+        "/home/khalid/Projects:/home/khalid/Projects",
+        "mcp/filesystem",
+        "/home/khalid/Projects"
+      ]
+    }    
+  }
+}


### PR DESCRIPTION
## Description
This PR adds the Windsurf rules configuration file that defines the MCP servers and their configurations for the project.

## Changes
- Added `mcp_config.json` with configurations for GitHub, Fetch, and Filesystem MCP servers
- Configured Docker-based MCP servers with appropriate environment variables and volume mounts
- Removed sensitive GitHub Personal Access Token from configuration (should be provided through environment variables)

## MCP Servers Configured
1. GitHub Server:
   - Uses official GitHub MCP server Docker image
   - Configured with GitHub host configuration
   - GitHub Personal Access Token should be provided through environment variables

2. Fetch Server:
   - Uses MCP Fetch server Docker image
   - Configured for internet content fetching

3. Filesystem Server:
   - Uses MCP Filesystem server Docker image
   - Configured with volume mount to project directory
   - Set up with proper path configuration